### PR TITLE
Fix API base URLs

### DIFF
--- a/frontend/src/services/brand.service.js
+++ b/frontend/src/services/brand.service.js
@@ -163,7 +163,8 @@ export const brandService = {
         }
       });
       
-      const url = `http://localhost:5000/api/v1/brands${queryParams.toString() ? '?' + queryParams.toString() : ''}`;
+      const baseUrl = process.env.REACT_APP_API_URL || 'http://localhost:5000/api/v1';
+      const url = `${baseUrl}/brands${queryParams.toString() ? '?' + queryParams.toString() : ''}`;
       console.log('Fetching from URL:', url);
       
       const response = await fetch(url, {
@@ -207,7 +208,8 @@ export const brandService = {
     try {
       console.log('Making brand API call with fetch for ID:', id);
       
-      const url = `http://localhost:5000/api/v1/brands/${id}`;
+      const baseUrl = process.env.REACT_APP_API_URL || 'http://localhost:5000/api/v1';
+      const url = `${baseUrl}/brands/${id}`;
       console.log('Fetching from URL:', url);
       
       const response = await fetch(url, {

--- a/frontend/src/services/category.service.js
+++ b/frontend/src/services/category.service.js
@@ -109,7 +109,7 @@ export const categoryService = {
 
     try {
       console.log('Making categories API call with fetch to avoid redirect loop');
-      
+
       // Build query string from params
       const queryParams = new URLSearchParams();
       Object.entries(params).forEach(([key, value]) => {
@@ -117,8 +117,9 @@ export const categoryService = {
           queryParams.append(key, value);
         }
       });
-      
-      const url = `http://localhost:5000/api/v1/categories${queryParams.toString() ? '?' + queryParams.toString() : ''}`;
+
+      const baseUrl = process.env.REACT_APP_API_URL || 'http://localhost:5000/api/v1';
+      const url = `${baseUrl}/categories${queryParams.toString() ? '?' + queryParams.toString() : ''}`;
       console.log('Fetching from URL:', url);
       
       const response = await fetch(url, {


### PR DESCRIPTION
## Summary
- ensure Brand and Category services respect environment API URL

## Testing
- `npm test -- --passWithNoTests` in `backend`
- `npm test -- --watchAll=false --passWithNoTests` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_683f801b3db88322af1a2e7cb26ef5d3