### PR TITLE
Remove mocks and hook up detail pages to API

### DIFF
--- a/frontend/src/pages/OrderDetail.js
+++ b/frontend/src/pages/OrderDetail.js
@@ -27,6 +27,7 @@ import PaymentIcon from '@mui/icons-material/Payment';
 import ScheduleIcon from '@mui/icons-material/Schedule';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
+import { orderService } from '../services/order.service';
 
 // Status mapping for visualization
 const orderStatusMap = {
@@ -37,43 +38,6 @@ const orderStatusMap = {
   'cancelled': { color: 'error', icon: <CancelIcon />, label: 'لغو شده' },
 };
 
-// Sample order data - in production this would come from an API
-const sampleOrder = {
-  id: '123456',
-  date: '1403/03/15',
-  status: 'processing',
-  paymentMethod: 'کارت بانکی',
-  paymentStatus: 'پرداخت شده',
-  shipping: {
-    address: 'تهران، خیابان ولیعصر، کوچه بهار، پلاک 12، واحد 3',
-    city: 'تهران',
-    postalCode: '1234567890',
-    phone: '09123456789',
-    trackingNumber: 'TRK123456789',
-  },
-  items: [
-    {
-      id: 1,
-      name: 'گارد محافظ گوشی مدل A52',
-      price: 1250000,
-      quantity: 1,
-      image: 'https://via.placeholder.com/80',
-    },
-    {
-      id: 2,
-      name: 'محافظ صفحه نمایش گلس',
-      price: 850000,
-      quantity: 2,
-      image: 'https://via.placeholder.com/80',
-    },
-  ],
-  totals: {
-    subtotal: 2950000,
-    shipping: 350000,
-    discount: 500000,
-    total: 2800000,
-  },
-};
 
 const OrderDetail = () => {
   const { orderId } = useParams();
@@ -83,16 +47,17 @@ const OrderDetail = () => {
   const { isAuthenticated } = useSelector((state) => state.auth);
 
   useEffect(() => {
-    // Simulating API call to fetch order details
-    const fetchOrder = () => {
+    const fetchOrder = async () => {
       setLoading(true);
-      
-      // In production, replace this with an actual API call
-      setTimeout(() => {
-        // Pretend this is data from the API
-        setOrder(sampleOrder);
+      try {
+        const response = await orderService.getOrderDetails(orderId);
+        const data = response.data || response;
+        setOrder(data);
+      } catch (err) {
+        setError(err.message || 'خطا در دریافت جزئیات سفارش');
+      } finally {
         setLoading(false);
-      }, 800);
+      }
     };
 
     if (isAuthenticated && orderId) {

--- a/frontend/src/pages/ProductDetail.js
+++ b/frontend/src/pages/ProductDetail.js
@@ -37,6 +37,7 @@ import RelatedProducts from '../components/RelatedProducts';
 import ReviewSection from '../components/ReviewSection';
 import Loading from '../components/Loading';
 import ContactCTA from '../components/ContactCTA';
+import { productService } from '../services/product.service';
 
 const CART_ENABLED = String(process.env.REACT_APP_CART_ENABLED).toLowerCase() === 'true';
 
@@ -55,54 +56,9 @@ const ProductDetail = () => {
     const fetchProduct = async () => {
       dispatch(fetchProductStart());
       try {
-        // In a real app, this would be an API call
-        // For now, we'll use a timeout to simulate a network request
-        setTimeout(() => {
-          // Sample product data for demonstration
-          const sampleProduct = {
-            id: id,
-            name: 'چراغ جلو دنا ایران خودرو',
-            slug: 'iran-khodro-dena-headlight-assembly',
-            brand: 'ایران خودرو',
-            brandSlug: 'irankhodro',
-            price: 2850000,
-            discountPrice: 2650000,
-            discount: 7,
-            rating: 4.6,
-            reviewCount: 42,
-            stockQuantity: 15,
-            sku: 'IK-DN-HL-001',
-            category: 'قطعات بدنه',
-            subcategory: 'چراغ و روشنایی',
-            description: 'چراغ جلو اصلی خودروی دنا با کیفیت بالا و مطابق با استانداردهای شرکت ایران خودرو.',
-            fullDescription: 'چراغ جلو اصلی خودروی دنا با کیفیت بالا و مطابق با استانداردهای شرکت ایران خودرو. این چراغ دارای لنز شیشه‌ای با کیفیت و رفلکتور آلومینیومی است که نور را به خوبی منعکس می‌کند. این محصول با دقت بالا طراحی شده تا دقیقاً با خودروی دنا مطابقت داشته باشد و نصب آن بسیار آسان است. این چراغ با گارانتی یک ساله عرضه می‌شود و در صورت بروز هرگونه مشکل، می‌توانید آن را تعویض نمایید.',
-            images: [
-              '/images/products/dena-headlight-1.jpg',
-              '/images/products/dena-headlight-2.jpg',
-              '/images/products/dena-headlight-3.jpg',
-            ],
-            specifications: [
-              { name: 'برند', value: 'ایران خودرو' },
-              { name: 'مدل خودرو', value: 'دنا' },
-              { name: 'سال تولید', value: '1398-1402' },
-              { name: 'جنس بدنه', value: 'پلاستیک ABS با مقاومت بالا' },
-              { name: 'جنس لنز', value: 'شیشه‌ای' },
-              { name: 'نوع لامپ', value: 'هالوژن' },
-              { name: 'تعداد لامپ', value: '2 عدد' },
-              { name: 'وزن', value: '1.8 کیلوگرم' },
-              { name: 'ابعاد', value: '35 × 25 × 15 سانتی‌متر' },
-              { name: 'گارانتی', value: '12 ماه' },
-            ],
-            compatibleModels: ['دنا', 'دنا پلاس', 'دنا پلاس توربو'],
-            isOriginal: true,
-            installationDifficulty: 'آسان',
-            installationTime: '30 دقیقه',
-            tags: ['چراغ جلو', 'دنا', 'ایران خودرو', 'قطعات بدنه'],
-            relatedProducts: [1, 2, 3, 4],
-          };
-          
-          dispatch(fetchProductSuccess(sampleProduct));
-        }, 500);
+        const response = await productService.getProduct(id);
+        const data = response.data || response;
+        dispatch(fetchProductSuccess(data));
       } catch (error) {
         dispatch(fetchProductFailure(error.message));
       }

--- a/frontend/src/services/order.service.js
+++ b/frontend/src/services/order.service.js
@@ -1,17 +1,9 @@
 import api from './api';
-import { getOrders, getOrderById, getOrdersByUserId, updateOrderStatus, createOrder } from './mockData';
-
-const USE_MOCK = true; // Toggle this to switch between mock and real API
 
 export const orderService = {
-  /**
-   * Create a new order
-   * @param {Object} orderData - Order data
-   * @returns {Promise} Promise with order data
-   */
-  createOrder: async (orderData) => {
+  // Create a new order
+  async createOrder(orderData) {
     try {
-      // For guest orders, use the guest endpoint
       const endpoint = orderData.guestInfo ? '/orders/guest' : '/orders';
       const response = await api.post(endpoint, orderData);
       return response.data;
@@ -19,12 +11,9 @@ export const orderService = {
       throw error.response?.data?.message || 'خطا در ایجاد سفارش';
     }
   },
-  
-  /**
-   * Get user orders
-   * @returns {Promise} Promise with order list
-   */
-  getUserOrders: async () => {
+
+  // Get orders for authenticated user
+  async getUserOrders() {
     try {
       const response = await api.get('/orders/user');
       return response.data;
@@ -32,13 +21,9 @@ export const orderService = {
       throw error.response?.data?.message || 'خطا در دریافت سفارشات';
     }
   },
-  
-  /**
-   * Get order details
-   * @param {string} orderId - Order ID
-   * @returns {Promise} Promise with order details
-   */
-  getOrderDetails: async (orderId) => {
+
+  // Get order details
+  async getOrderDetails(orderId) {
     try {
       const response = await api.get(`/orders/${orderId}`);
       return response.data;
@@ -46,30 +31,21 @@ export const orderService = {
       throw error.response?.data?.message || 'خطا در دریافت جزئیات سفارش';
     }
   },
-  
-  /**
-   * Get order by tracking code (can be used by guests)
-   * @param {string} trackingCode - Order tracking code
-   * @param {string} phoneNumber - Phone number used for the order
-   * @returns {Promise} Promise with order details
-   */
-  getOrderByTracking: async (trackingCode, phoneNumber) => {
+
+  // Get order by tracking code
+  async getOrderByTracking(trackingCode, phoneNumber) {
     try {
       const response = await api.get(`/orders/tracking/${trackingCode}`, {
-        params: { phone: phoneNumber }
+        params: { phone: phoneNumber },
       });
       return response.data;
     } catch (error) {
       throw error.response?.data?.message || 'خطا در دریافت اطلاعات سفارش';
     }
   },
-  
-  /**
-   * Cancel an order
-   * @param {string} orderId - Order ID
-   * @returns {Promise} Promise with result
-   */
-  cancelOrder: async (orderId) => {
+
+  // Cancel an order
+  async cancelOrder(orderId) {
     try {
       const response = await api.post(`/orders/${orderId}/cancel`);
       return response.data;
@@ -78,22 +54,17 @@ export const orderService = {
     }
   },
 
-  // Admin functions
-  getAllOrders: async (params = {}) => {
-    if (USE_MOCK) {
-      return getOrders();
-    }
+  // Admin: get all orders
+  async getAllOrders(params = {}) {
     const response = await api.get('/orders', { params });
     return response.data;
   },
 
-  updateOrderStatus: async (id, status) => {
-    if (USE_MOCK) {
-      return updateOrderStatus(id, status);
-    }
+  // Admin: update order status
+  async updateOrderStatus(id, status) {
     const response = await api.put(`/orders/${id}/status`, { status });
     return response.data;
-  }
+  },
 };
 
 export default orderService;

--- a/frontend/src/services/product.service.js
+++ b/frontend/src/services/product.service.js
@@ -1,158 +1,8 @@
 import api from './api';
 
-const USE_MOCK = false; // Set to true for development with mock data
-
-// Mock data for development
-const mockProducts = [
-  {
-    _id: '1',
-    name: 'فیلتر روغن سایپا پراید',
-    description: 'فیلتر روغن با کیفیت بالا برای خودروهای سایپا پراید',
-    price: 100000,
-    discountPrice: 85000,
-    category: { _id: 'cat1', name: 'موتور' },
-    brand: { _id: 'brand1', name: 'سایپا' },
-    stock: 45,
-    sku: 'SAI-FIL-001',
-    weight: 500,
-    featured: true,
-    images: [
-      { url: '/images/products/filter.jpg', alt: 'فیلتر روغن سایپا' }
-    ],
-    specifications: [
-      { name: 'نوع', value: 'فیلتر روغن' },
-      { name: 'سازگاری', value: 'سایپا پراید، تیبا' }
-    ],
-    compatibleVehicles: [
-      { make: 'سایپا', model: 'پراید', year: 2020 },
-      { make: 'سایپا', model: 'تیبا', year: 2019 }
-    ],
-    rating: 4.5,
-    numReviews: 87,
-    createdAt: '2024-01-15T10:30:00Z',
-    updatedAt: '2024-01-20T14:45:00Z'
-  },
-  {
-    _id: '2',
-    name: 'لنت ترمز پژو 206',
-    description: 'لنت ترمز با کیفیت اروپایی برای خودروهای پژو ایران خودرو',
-    price: 200000,
-    discountPrice: null,
-    category: { _id: 'cat2', name: 'ترمز' },
-    brand: { _id: 'brand2', name: 'ایران خودرو' },
-    stock: 32,
-    sku: 'IKC-BRK-002',
-    weight: 800,
-    featured: false,
-    images: [
-      { url: '/images/products/brake.jpg', alt: 'لنت ترمز پژو' }
-    ],
-    specifications: [
-      { name: 'نوع', value: 'لنت ترمز' },
-      { name: 'مواد', value: 'سرامیک' }
-    ],
-    compatibleVehicles: [
-      { make: 'ایران خودرو', model: 'پژو 206', year: 2018 },
-      { make: 'ایران خودرو', model: 'پژو 207', year: 2019 }
-    ],
-    rating: 4.8,
-    numReviews: 65,
-    createdAt: '2024-01-10T08:15:00Z',
-    updatedAt: '2024-01-18T16:20:00Z'
-  }
-];
-
-// eslint-disable-next-line no-unused-vars
-const mockCategories = [
-  { _id: 'cat1', name: 'موتور' },
-  { _id: 'cat2', name: 'ترمز' },
-  { _id: 'cat3', name: 'برق خودرو' },
-  { _id: 'cat4', name: 'سیستم تعلیق' }
-];
-
-// eslint-disable-next-line no-unused-vars
-const mockBrands = [
-  { _id: 'brand1', name: 'سایپا' },
-  { _id: 'brand2', name: 'ایران خودرو' },
-  { _id: 'brand3', name: 'MVM' },
-  { _id: 'brand4', name: 'بهمن موتور' },
-  { _id: 'brand5', name: 'بوش' }
-];
-
-// Helper function to simulate API delay
-const delay = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-
 export const productService = {
   // Get all products with filtering and pagination
-  getProducts: async (params = {}) => {
-    if (USE_MOCK) {
-      await delay(500); // Simulate network delay
-      
-      let filteredProducts = [...mockProducts];
-      
-      // Apply search filter
-      if (params.search) {
-        const searchTerm = params.search.toLowerCase();
-        filteredProducts = filteredProducts.filter(product =>
-          product.name.toLowerCase().includes(searchTerm) ||
-          product.description.toLowerCase().includes(searchTerm) ||
-          product.sku.toLowerCase().includes(searchTerm) ||
-          product.category.name.toLowerCase().includes(searchTerm) ||
-          product.brand.name.toLowerCase().includes(searchTerm)
-        );
-      }
-      
-      // Apply category filter
-      if (params.category) {
-        filteredProducts = filteredProducts.filter(product =>
-          product.category._id === params.category
-        );
-      }
-      
-      // Apply brand filter
-      if (params.brand) {
-        filteredProducts = filteredProducts.filter(product =>
-          product.brand._id === params.brand
-        );
-      }
-      
-      // Apply stock level filter
-      if (params.stockLevel) {
-        switch (params.stockLevel) {
-          case 'available':
-            filteredProducts = filteredProducts.filter(product => product.stock > 0);
-            break;
-          case 'low':
-            filteredProducts = filteredProducts.filter(product => product.stock > 0 && product.stock < 10);
-            break;
-          case 'out':
-            filteredProducts = filteredProducts.filter(product => product.stock === 0);
-            break;
-          default:
-            // No additional filtering for unknown stock levels
-            break;
-        }
-      }
-      
-      // Pagination
-      const page = parseInt(params.page) || 1;
-      const limit = parseInt(params.limit) || 10;
-      const startIndex = (page - 1) * limit;
-      const endIndex = startIndex + limit;
-      
-      const paginatedProducts = filteredProducts.slice(startIndex, endIndex);
-      
-      return {
-        products: paginatedProducts,
-        pagination: {
-          total: filteredProducts.length,
-          page: page,
-          limit: limit,
-          pages: Math.ceil(filteredProducts.length / limit)
-        }
-      };
-    }
-
+  async getProducts(params = {}) {
     try {
       const response = await api.get('/products', { params });
       return response.data;
@@ -163,16 +13,7 @@ export const productService = {
   },
 
   // Get single product by ID
-  getProduct: async (id) => {
-    if (USE_MOCK) {
-      await delay(300);
-      const product = mockProducts.find(p => p._id === id);
-      if (!product) {
-        throw new Error('Product not found');
-      }
-      return product;
-    }
-
+  async getProduct(id) {
     try {
       const response = await api.get(`/products/${id}`);
       return response.data;
@@ -183,26 +24,10 @@ export const productService = {
   },
 
   // Create new product
-  createProduct: async (productData) => {
-    if (USE_MOCK) {
-      await delay(800);
-      const newProduct = {
-        _id: Date.now().toString(),
-        ...productData,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        rating: 0,
-        numReviews: 0
-      };
-      mockProducts.push(newProduct);
-      return newProduct;
-    }
-
+  async createProduct(productData) {
     try {
       const response = await api.post('/products', productData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
+        headers: { 'Content-Type': 'multipart/form-data' },
       });
       return response.data;
     } catch (error) {
@@ -212,26 +37,10 @@ export const productService = {
   },
 
   // Update existing product
-  updateProduct: async (id, productData) => {
-    if (USE_MOCK) {
-      await delay(800);
-      const index = mockProducts.findIndex(p => p._id === id);
-      if (index === -1) {
-        throw new Error('Product not found');
-      }
-      mockProducts[index] = {
-        ...mockProducts[index],
-        ...productData,
-        updatedAt: new Date().toISOString()
-      };
-      return mockProducts[index];
-    }
-
+  async updateProduct(id, productData) {
     try {
       const response = await api.put(`/products/${id}`, productData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
+        headers: { 'Content-Type': 'multipart/form-data' },
       });
       return response.data;
     } catch (error) {
@@ -241,17 +50,7 @@ export const productService = {
   },
 
   // Delete product
-  deleteProduct: async (id) => {
-    if (USE_MOCK) {
-      await delay(500);
-      const index = mockProducts.findIndex(p => p._id === id);
-      if (index === -1) {
-        throw new Error('Product not found');
-      }
-      mockProducts.splice(index, 1);
-      return { message: 'Product deleted successfully' };
-    }
-
+  async deleteProduct(id) {
     try {
       const response = await api.delete(`/products/${id}`);
       return response.data;
@@ -262,17 +61,9 @@ export const productService = {
   },
 
   // Get featured products
-  getFeaturedProducts: async (limit = 10) => {
-    if (USE_MOCK) {
-      await delay(400);
-      const featured = mockProducts.filter(p => p.featured).slice(0, limit);
-      return { products: featured };
-    }
-
+  async getFeaturedProducts(limit = 10) {
     try {
-      const response = await api.get('/products/featured', {
-        params: { limit }
-      });
+      const response = await api.get('/products/featured', { params: { limit } });
       return response.data;
     } catch (error) {
       console.error('Error fetching featured products:', error);
@@ -281,14 +72,10 @@ export const productService = {
   },
 
   // Search products
-  searchProducts: async (query, filters = {}) => {
-    if (USE_MOCK) {
-      return this.getProducts({ search: query, ...filters });
-    }
-
+  async searchProducts(query, filters = {}) {
     try {
       const response = await api.get('/products/search', {
-        params: { q: query, ...filters }
+        params: { q: query, ...filters },
       });
       return response.data;
     } catch (error) {
@@ -298,15 +85,9 @@ export const productService = {
   },
 
   // Get products by category
-  getProductsByCategory: async (categoryId, params = {}) => {
-    if (USE_MOCK) {
-      return this.getProducts({ category: categoryId, ...params });
-    }
-
+  async getProductsByCategory(categoryId, params = {}) {
     try {
-      const response = await api.get(`/products/category/${categoryId}`, {
-        params
-      });
+      const response = await api.get(`/products/category/${categoryId}`, { params });
       return response.data;
     } catch (error) {
       console.error('Error fetching products by category:', error);
@@ -315,15 +96,9 @@ export const productService = {
   },
 
   // Get products by brand
-  getProductsByBrand: async (brandId, params = {}) => {
-    if (USE_MOCK) {
-      return this.getProducts({ brand: brandId, ...params });
-    }
-
+  async getProductsByBrand(brandId, params = {}) {
     try {
-      const response = await api.get(`/products/brand/${brandId}`, {
-        params
-      });
+      const response = await api.get(`/products/brand/${brandId}`, { params });
       return response.data;
     } catch (error) {
       console.error('Error fetching products by brand:', error);
@@ -332,17 +107,7 @@ export const productService = {
   },
 
   // Update product stock
-  updateStock: async (id, stock) => {
-    if (USE_MOCK) {
-      await delay(300);
-      const product = mockProducts.find(p => p._id === id);
-      if (product) {
-        product.stock = stock;
-        product.updatedAt = new Date().toISOString();
-      }
-      return product;
-    }
-
+  async updateStock(id, stock) {
     try {
       const response = await api.put(`/products/${id}/stock`, { stock });
       return response.data;
@@ -353,23 +118,11 @@ export const productService = {
   },
 
   // Bulk update products
-  bulkUpdate: async (productIds, updateData) => {
-    if (USE_MOCK) {
-      await delay(1000);
-      productIds.forEach(id => {
-        const product = mockProducts.find(p => p._id === id);
-        if (product) {
-          Object.assign(product, updateData);
-          product.updatedAt = new Date().toISOString();
-        }
-      });
-      return { message: 'Products updated successfully' };
-    }
-
+  async bulkUpdate(productIds, updateData) {
     try {
       const response = await api.put('/products/bulk-update', {
         productIds,
-        updateData
+        updateData,
       });
       return response.data;
     } catch (error) {
@@ -378,60 +131,8 @@ export const productService = {
     }
   },
 
-  // Get products by vehicle model (NEW METHOD)
-  getProductsByModel: async (modelId, params = {}) => {
-    if (USE_MOCK) {
-      await delay(400);
-      // For mock data, filter products that have compatible vehicles matching the model
-      const modelMap = {
-        'pride_111': 'پراید',
-        'pride_131': 'پراید', 
-        'tiba': 'تیبا',
-        'peugeot_206': 'پژو 206',
-        'peugeot_pars': 'پژو پارس',
-        'samand_lx': 'سمند',
-        'dena': 'دنا',
-        'quick': 'کوییک',
-        'shahin': 'شاهین',
-        'runna': 'رانا'
-      };
-      
-      const modelName = modelMap[modelId];
-      if (!modelName) {
-        return { products: [], pagination: { total: 0, page: 1, limit: 10, pages: 0 } };
-      }
-      
-      const filteredProducts = mockProducts.filter(product =>
-        product.compatibleVehicles?.some(vehicle => 
-          vehicle.model.includes(modelName.split(' ')[0]) // Match main model name
-        )
-      );
-      
-      // Apply additional filters
-      let result = filteredProducts;
-      
-      if (params.category) {
-        result = result.filter(product => product.category._id === params.category);
-      }
-      
-      // Pagination
-      const page = parseInt(params.page) || 1;
-      const limit = parseInt(params.limit) || 10;
-      const startIndex = (page - 1) * limit;
-      const endIndex = startIndex + limit;
-      const paginatedProducts = result.slice(startIndex, endIndex);
-      
-      return {
-        products: paginatedProducts,
-        pagination: {
-          total: result.length,
-          page: page,
-          limit: limit,
-          pages: Math.ceil(result.length / limit)
-        }
-      };
-    }
-
+  // Get products by vehicle model
+  async getProductsByModel(modelId, params = {}) {
     try {
       const response = await api.get(`/products/model/${modelId}`, { params });
       return response.data;
@@ -441,50 +142,8 @@ export const productService = {
     }
   },
 
-  // Get products by manufacturer (NEW METHOD)
-  getProductsByManufacturer: async (manufacturerId, params = {}) => {
-    if (USE_MOCK) {
-      await delay(400);
-      const manufacturerMap = {
-        'saipa': 'سایپا',
-        'ikco': 'ایران خودرو'
-      };
-      
-      const manufacturerName = manufacturerMap[manufacturerId];
-      if (!manufacturerName) {
-        return { products: [], pagination: { total: 0, page: 1, limit: 10, pages: 0 } };
-      }
-      
-      const filteredProducts = mockProducts.filter(product =>
-        product.compatibleVehicles?.some(vehicle => 
-          vehicle.make === manufacturerName
-        )
-      );
-      
-      // Apply additional filters and pagination similar to getProductsByModel
-      let result = filteredProducts;
-      
-      if (params.category) {
-        result = result.filter(product => product.category._id === params.category);
-      }
-      
-      const page = parseInt(params.page) || 1;
-      const limit = parseInt(params.limit) || 10;
-      const startIndex = (page - 1) * limit;
-      const endIndex = startIndex + limit;
-      const paginatedProducts = result.slice(startIndex, endIndex);
-      
-      return {
-        products: paginatedProducts,
-        pagination: {
-          total: result.length,
-          page: page,
-          limit: limit,
-          pages: Math.ceil(result.length / limit)
-        }
-      };
-    }
-
+  // Get products by manufacturer
+  async getProductsByManufacturer(manufacturerId, params = {}) {
     try {
       const response = await api.get(`/products/manufacturer/${manufacturerId}`, { params });
       return response.data;
@@ -494,25 +153,8 @@ export const productService = {
     }
   },
 
-  // Get compatible vehicles for admin (NEW METHOD)
-  getCompatibleVehicles: async () => {
-    if (USE_MOCK) {
-      await delay(200);
-      // Return all unique vehicle combinations from existing products
-      const vehicles = new Set();
-      mockProducts.forEach(product => {
-        product.compatibleVehicles?.forEach(vehicle => {
-          vehicles.add(JSON.stringify({
-            make: vehicle.make,
-            model: vehicle.model,
-            year: vehicle.year
-          }));
-        });
-      });
-      
-      return Array.from(vehicles).map(v => JSON.parse(v));
-    }
-
+  // Get compatible vehicles
+  async getCompatibleVehicles() {
     try {
       const response = await api.get('/products/compatible-vehicles');
       return response.data;
@@ -520,7 +162,7 @@ export const productService = {
       console.error('Error fetching compatible vehicles:', error);
       throw error;
     }
-  }
+  },
 };
 
 export default productService;


### PR DESCRIPTION
## Summary
- fetch product detail from API instead of using a sample object
- fetch order detail via the API
- drop mock logic from order and product services

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend *(fails: jest module not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f827d3c448322ae9c3cc31cc7ad66